### PR TITLE
Install to $(HOME)/bin by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export DOCKER_IMAGE ?= getft/geodesic
 export DOCKER_TAG ?= dev
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_BUILD_FLAGS =
-export INSTALL_PATH ?= /usr/local/bin
+export INSTALL_PATH ?= $(HOME)/bin
 
 export BUILD_HARNESS_ORG ?= joshmyers
 export BUILD_HARNESS_BRANCH ?= master
@@ -23,7 +23,7 @@ build:
 	@make --no-print-directory docker:build
 
 install:
-	docker run --rm $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG) || (echo "Try: sudo make install"; exit 1)
+	@docker run --rm $(DOCKER_IMAGE_NAME) | bash -s $(DOCKER_TAG) || (echo "Try: sudo make install"; exit 1)
 
 run:
 	@geodesic

--- a/rootfs/templates/bootstrap
+++ b/rootfs/templates/bootstrap
@@ -42,6 +42,12 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+# Create INSTALL_PATH if doesn't exist
+if [ ! -d "${INSTALL_PATH}" ]; then
+	echo "INSTALL_PATH: ${INSTALL_PATH} not found. Creating." 2>&1
+	mkdir -p "${INSTALL_PATH}"
+fi
+
 # Check that we can write to install path
 if [ ! -w "${INSTALL_PATH}" ]; then
 	echo "Cannot write to ${INSTALL_PATH}. Please retry using sudo." 2>&1
@@ -69,6 +75,5 @@ if [ $? -eq 0 ]; then
 	exit 0
 else
 	echo "# Failed to install ${APP_NAME}"
-	echo "# Please let us know! Send an email to < hello@getft.com > with what went wrong."
 	exit 1
 fi


### PR DESCRIPTION
## what

Not a fan of having to ask for sudo to install into `/usr/local/bin` so
default to $HOME/bin, with the disadvantage now that you will need to
ensure to add $HOME/bin to your $PATH, like so `export PATH="$HOME/bin:$PATH"`